### PR TITLE
fix: work around xml2js null object prototypes

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -3,6 +3,8 @@ import columnify from 'columnify';
 import { red, green, bold } from 'colorette';
 import { EOL } from 'os';
 
+const toString = (v) => Object.prototype.toString.call(v);
+
 export const generateSummary = (summary) => {
   const data = {
     '> Name:': summary.name,
@@ -59,7 +61,7 @@ const generateTestcaseResult = (testcase) => {
   if (!isTestcaseSuccess(testcase)) {
     let errorLines = '';
     if (testcase.failure.join) {
-      errorLines = testcase.failure.join(EOL).split(EOL).join(EOL + '\t');
+      errorLines = testcase.failure.map(toString).join(EOL).split(EOL).join(EOL + '\t');
     } else {
       errorLines = testcase.failure;
     }


### PR DESCRIPTION
This commit https://github.com/Leonidas-from-XIV/node-xml2js/commit/581b19a62d88f8a3c068b5a45f4542c2d6a495a5 fixes a CVE but also breaks almost all libs using xml2js. This PR fixes that