### PR TITLE
Add support for outputting testcase logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.
 
 program
   .version(packageJson.version, '-v, --version')
+  .option('--logs', 'include log output for test cases')
   .usage('<junit.xml file path...>');
 
 program.parse(process.argv);
@@ -49,5 +50,8 @@ parseString.parseString(xmlStr, (err, result) => {
   result.testsuites.testsuite.forEach(t => {
     console.log(lib.generateTestsuiteSummary(t));
     console.log(lib.generateTestsuiteResult(t));
+    if (program.opts().logs) {
+      console.log(lib.generateTestsuiteLogs(t));
+    }
   });
 });

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ if (program.args.length < 1) {
   process.exit(1);
 }
 
+const options = program.opts();
 const filepath = program.args[0];
 if (!fs.existsSync(filepath)) {
   console.warn('File does not exists in filepath provided');
@@ -50,7 +51,7 @@ parseString.parseString(xmlStr, (err, result) => {
   result.testsuites.testsuite.forEach(t => {
     console.log(lib.generateTestsuiteSummary(t));
     console.log(lib.generateTestsuiteResult(t));
-    if (program.opts().logs) {
+    if (options.logs) {
       console.log(lib.generateTestsuiteLogs(t));
     }
   });

--- a/lib.js
+++ b/lib.js
@@ -99,14 +99,14 @@ export const generateTestsuiteLogs = (suiteResult) => {
   const testscases = suiteResult.testcase;
 
   if (testscases) {
-    let errLogs = [...testscases.map(testcase => testcase["system-err"] ? testcase["system-err"].join(EOL).split(EOL).join(EOL + '\t') : "")].filter(a => a != "");
+    let errLogs = [...testscases.map(testcase => testcase['system-err'] ? testcase['system-err'].join(EOL).split(EOL).join(EOL + '\t') : '')].filter(a => a != '');
     if (errLogs.length) {
-      result.push(EOL, "   > Error Log output:", EOL, EOL, '\t', ...errLogs)
+      result.push(EOL, '   > Error Log output:', EOL, EOL, '\t', ...errLogs);
     }
 
-    let outLogs = [...testscases.map(testcase => testcase["system-out"] ? testcase["system-out"].join(EOL).split(EOL).join(EOL + '\t') : "" )].filter(a => a != "")
+    let outLogs = [...testscases.map(testcase => testcase['system-out'] ? testcase['system-out'].join(EOL).split(EOL).join(EOL + '\t') : '')].filter(a => a != '');
     if (outLogs.length) {
-      result.push(EOL, "   > Standard Log output:", EOL, EOL, '\t', ...outLogs)
+      result.push(EOL, '   > Standard Log output:', EOL, EOL, '\t', ...outLogs);
     }
   }
 

--- a/lib.js
+++ b/lib.js
@@ -97,27 +97,29 @@ export const generateTestsuiteResult = (suiteResult) => {
 };
 
 export const generateTestsuiteLogs = (suiteResult) => {
-  let result = [];
+  let result = [EOL];
   const testscases = suiteResult.testcase;
 
   if (testscases) {
-    let errLogs = [...testscases.map(testcase => formatLogLine(testcase['system-err']))].filter(a => a !== '');
+    const errLogs = testscases.map(testcase => formatLogLine(testcase['system-err'])).filter(a => a);
     if (errLogs.length) {
-      result.push(EOL, '   > Error Log output:', EOL, EOL, '\t', ...errLogs);
+      result.push(`   ${logSymbols.info} Error Log output:`, EOL, '\t', ...errLogs);
     }
 
-    let outLogs = [...testscases.map(testcase => formatLogLine(testcase['system-out']))].filter(a => a !== '');
+    const outLogs = testscases.map(testcase => formatLogLine(testcase['system-out'])).filter(a => a);
     if (outLogs.length) {
-      result.push(EOL, '   > Standard Log output:', EOL, EOL, '\t', ...outLogs);
+      result.push(`   ${logSymbols.info} Standard Log output:`, EOL, '\t', ...outLogs);
     }
   }
 
   return result.join('');
 };
 
-const formatLogLine = (logLine) => {
-  if (logLine) {
-    return logLine.join(EOL).split(EOL).join(EOL + '\t');
+const formatLogLine = (log) => {
+  if (!log) {
+    return ''
+  } else if (log.join) {
+    return log.join(EOL).split(EOL).join(EOL + '\t');
   }
-  return '';
+  return log;
 };

--- a/lib.js
+++ b/lib.js
@@ -117,7 +117,7 @@ export const generateTestsuiteLogs = (suiteResult) => {
 
 const formatLogLine = (log) => {
   if (!log) {
-    return ''
+    return '';
   } else if (log.join) {
     return log.join(EOL).split(EOL).join(EOL + '\t');
   }

--- a/lib.js
+++ b/lib.js
@@ -99,16 +99,23 @@ export const generateTestsuiteLogs = (suiteResult) => {
   const testscases = suiteResult.testcase;
 
   if (testscases) {
-    let errLogs = [...testscases.map(testcase => testcase['system-err'] ? testcase['system-err'].join(EOL).split(EOL).join(EOL + '\t') : '')].filter(a => a != '');
+    let errLogs = [...testscases.map(testcase => formatLogLine(testcase['system-err']))].filter(a => a !== '');
     if (errLogs.length) {
       result.push(EOL, '   > Error Log output:', EOL, EOL, '\t', ...errLogs);
     }
 
-    let outLogs = [...testscases.map(testcase => testcase['system-out'] ? testcase['system-out'].join(EOL).split(EOL).join(EOL + '\t') : '')].filter(a => a != '');
+    let outLogs = [...testscases.map(testcase => formatLogLine(testcase['system-out']))].filter(a => a !== '');
     if (outLogs.length) {
       result.push(EOL, '   > Standard Log output:', EOL, EOL, '\t', ...outLogs);
     }
   }
 
   return result.join('');
+};
+
+const formatLogLine = (logLine) => {
+  if (logLine) {
+    return logLine.join(EOL).split(EOL).join(EOL + '\t');
+  }
+  return '';
 };

--- a/lib.js
+++ b/lib.js
@@ -59,9 +59,9 @@ const generateTestcaseResult = (testcase) => {
   if (!isTestcaseSuccess(testcase)) {
     let errorLines = '';
     if (testcase.failure.join) {
-      errorLines = testcase.failure.join(EOL).split(EOL).join(EOL + '\t');
+      errorLines = testcase.failure.map(f => f._).join(EOL).split(EOL).join(EOL + '\t');
     } else {
-      errorLines = testcase.failure;
+      errorLines = testcase.failure.map(f => f._);
     }
 
     resultParagraph += EOL + '\t' + errorLines;
@@ -92,4 +92,23 @@ export const generateTestsuiteResult = (suiteResult) => {
   }
 
   return result.join(EOL);
+};
+
+export const generateTestsuiteLogs = (suiteResult) => {
+  let result = [];
+  const testscases = suiteResult.testcase;
+
+  if (testscases) {
+    let errLogs = [...testscases.map(testcase => testcase["system-err"] ? testcase["system-err"].join(EOL).split(EOL).join(EOL + '\t') : "")].filter(a => a != "");
+    if (errLogs.length) {
+      result.push(EOL, "   > Error Log output:", EOL, EOL, '\t', ...errLogs)
+    }
+
+    let outLogs = [...testscases.map(testcase => testcase["system-out"] ? testcase["system-out"].join(EOL).split(EOL).join(EOL + '\t') : "" )].filter(a => a != "")
+    if (outLogs.length) {
+      result.push(EOL, "   > Standard Log output:", EOL, EOL, '\t', ...outLogs)
+    }
+  }
+
+  return result.join('');
 };

--- a/lib.js
+++ b/lib.js
@@ -59,9 +59,11 @@ const generateTestcaseResult = (testcase) => {
   if (!isTestcaseSuccess(testcase)) {
     let errorLines = '';
     if (testcase.failure.join) {
-      errorLines = testcase.failure.map(f => f._).join(EOL).split(EOL).join(EOL + '\t');
+      errorLines = testcase.failure.map(f => f['$'] && f['$'].message ? f['$'].message : f['_'])
+        .join(EOL).split(EOL).join(EOL + '\t');
     } else {
-      errorLines = testcase.failure.map(f => f._);
+      errorLines = testcase.failure['$'] && testcase.failure['$'].message ?
+        testcase.failure['$'].message : testcase.failure['_'];
     }
 
     resultParagraph += EOL + '\t' + errorLines;


### PR DESCRIPTION
Added a new `--logs` flag to support outputting the stdout and stderr logs for each test case. This new flag is disabled by default to preserve existing functionality. 