### PR TITLE
Show indicator for skipped test suites and cases

### DIFF
--- a/lib.test.js
+++ b/lib.test.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { red, green, blue, bold } from 'colorette';
 
 import * as lib from './lib.js';
 
@@ -76,5 +77,68 @@ describe('lib', () => {
       };
       assert.deepEqual(lib.findSummaryFromTestsuites(testsuites), expectedOutput);
     });
+  });
+
+  describe('generateTestsuiteSummary()', () => {
+    const tests = [
+      {
+        title: 'should correctly display passing test suites',
+        summary: {
+          name: 'Passing Suite',
+          time: '2.5',
+          tests: '1',
+          errors: '0',
+          failures: '0',
+          skipped: '0',
+        },
+        expectedPrefix: `${bold(green('PASS'))}`,
+      },
+      {
+        title: 'should correctly display failing test suites',
+        summary: {
+          name: 'Failing Suite',
+          time: '2.5',
+          tests: '1',
+          errors: '0',
+          failures: '1',
+          skipped: '0',
+        },
+        expectedPrefix: `${bold(red('FAIL'))}`,
+      },
+      {
+        title: 'should correctly display erroring test suites',
+        summary: {
+          name: 'Erroring Suite',
+          time: '2.5',
+          tests: '1',
+          errors: '1',
+          failures: '0',
+          skipped: '0',
+        },
+        expectedPrefix: `${bold(red('FAIL'))}`,
+      },
+      {
+        title: 'should correctly display skipped test suites',
+        summary: {
+          name: 'Skipped Suite',
+          time: '2.5',
+          tests: '1',
+          errors: '0',
+          failures: '0',
+          skipped: '1',
+        },
+        expectedPrefix: `${bold(blue('SKIP'))}`,
+      },
+    ];
+
+    for (const test of tests) {
+      it(test.title, () => {
+        const testSuite = {
+          $: test.summary,
+        };
+        const expected = ` ${test.expectedPrefix} ${test.summary.name} (${test.summary.time})`;
+        assert.deepEqual(lib.generateTestsuiteSummary(testSuite), expected);
+      });
+    }
   });
 });


### PR DESCRIPTION
Correctly show test suites and cases that have been skipped as `SKIP` or `s` rather than `PASS`.

Example output:

![Screenshot 2023-08-24 at 7 42 58 pm](https://github.com/amalfra/junit-cli-report-viewer/assets/3384072/23822dc3-2db8-4d00-9781-ff0c8ee1d629)

Note: my colour scheme makes blue look green 🤷 